### PR TITLE
jsonschema-specifications 2025.9.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,35 @@
-{% set version = "2023.7.1" %}
+{% set name = "jsonschema-specifications" %}
+{% set version = "2025.9.1" %}
 
 package:
-  name: jsonschema-specifications
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jsonschema-specifications/jsonschema_specifications-{{ version }}.tar.gz
-  sha256: c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   host:
     - hatch-vcs
-    - hatchling
+    - hatchling >=1.27.0
     - pip
     - python
   run:
-    - importlib_resources >=1.4.0 # [py<39]
     - python
-    - referencing >=0.28.0
+    - referencing >=0.31.0
 
 test:
   imports:
     - jsonschema_specifications
   commands:
     - pip check
-    - pytest -vv --pyargs jsonschema_specifications --cov-branch --cov=jsonschema_specifications --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=88
+    - pytest -ra -v --tb=short --pyargs jsonschema_specifications --cov-branch --cov=jsonschema_specifications --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=88
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ test:
     - jsonschema_specifications
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -ra -v --tb=short --pyargs jsonschema_specifications --cov-branch --cov=jsonschema_specifications --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=88
   requires:
     - pip


### PR DESCRIPTION
jsonschema-specifications 2025.9.1 

**Destination channel:** Defaults

### Links

- [PKG-10570]
- dev_url:        https://github.com/python-jsonschema/jsonschema-specifications/tree/v2025.9.1
- conda_forge:    https://github.com/conda-forge/jsonschema-specifications-feedstock
- pypi:           https://pypi.org/project/jsonschema-specifications/2025.9.1
- pypi inspector: https://inspector.pypi.io/project/jsonschema-specifications/2025.9.1

### Explanation of changes:

- version updated 2023.7.1 → 2025.9.1
- build number reset 1 → 0
- python minimum raised: skip py<38 → py<39
- host: pinned hatchling to >=1.27.0
- run: referencing bumped >=0.28.0 → >=0.31.0
- tests: updated pytest command/flags to -ra -v --tb=short


[PKG-10570]: https://anaconda.atlassian.net/browse/PKG-10570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ